### PR TITLE
New: send announcement to validator-announce

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,34 @@ jobs:
                     :ship: ⅔ of Super Validator nodes have upgraded to this release, including the GSF Super Validator node
                     *SV node status here*: https://sync.global/sv-network
                     *Release notes here*: https://docs.dev.sync.global/release_notes.html
+
+      - name: Announce to validator-announce@lists.sync.global
+        env: 
+          VALIODATOR_OPERATORS_GROUP_ID: "133138"
+        run: |
+          LOGIN_RESPONSE_COOKIES=$(curl -XPOST -c cookies.txt "https://lists.sync.global/api/v1/login" \
+            -d "email=${{ secrets.GROUPS_IO_USER }}&password=${{ secrets.GROUPS_IO_PASS }}")
+          CSRF_TOKEN=$(echo $LOGIN_RESPONSE_COOKIES | jq -r '.user.csrf_token')
+          DRAFT_ID=$(curl "https://lists.sync.global/api/v1/newdraft" \
+            -b "cookies.txt" \
+            -d "draft_type=draft_type_post" \
+            -d "group_id=${VALIODATOR_OPERATORS_GROUP_ID}&csrf=${CSRF_TOKEN}" \
+            | jq -r '.id')
+
+          # Replace version in template
+          sed "s/{{VERSION}}/${{ env.GSF_DEVNET_VERSION }}/g" ./ci/message_template.html > message.html
+
+          curl "https://lists.sync.global/api/v1/updatedraft" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -b "cookies.txt" \
+            -d "draft_id=${DRAFT_ID}" \
+            -d "group_id=${VALIODATOR_OPERATORS_GROUP_ID}&csrf=${CSRF_TOKEN}" \
+            -d "subject=Splice release ${{ env.GSF_DEVNET_VERSION }} is ready for deployment on DevNet" \
+            --data-urlencode "body@message.html"
+          
+          curl "https://lists.sync.global/api/v1/postdraft" \
+            -b "cookies.txt" \
+            -d "draft_id=${DRAFT_ID}" \
+            -d "group_id=${VALIODATOR_OPERATORS_GROUP_ID}&csrf=${CSRF_TOKEN}"
+
+          rm cookies.txt message.html

--- a/ci/message_template.html
+++ b/ci/message_template.html
@@ -1,0 +1,21 @@
+<div class="user-content">
+  <p>
+    <span role="img" aria-label="Party Popper" style="display: inline-block; width: 22px; height: 22px; vertical-align: middle;">
+      <img src="https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-medium/1f389@2x.png" alt="Party Popper" style="width: 100%; height: 100%;" loading="lazy">
+    </span>
+    <span>Splice release </span><code>{{VERSION}}</code> is ready for deployment on DevNet, and is available from the GSF
+  </p>
+  <p>
+    <span role="img" aria-label="Partydocker" style="display: inline-block; width: 22px; height: 22px; vertical-align: middle;">
+      <img src="https://emoji.slack-edge.com/T07LSPYDRT4/partydocker/72e4a7607734e18c.gif" alt="Partydocker" style="width: 100%; height: 100%;" loading="lazy">
+    </span>
+    <span>⅔ of Super Validator</span> nodes have upgraded to this release, including the GSF Super Validator node
+  </p>
+  <p>
+    <strong>SV node status:</strong> <a href="https://sync.global/sv-network" target="_blank" rel="noopener noreferrer">sync.global/sv-network</a>
+  </p>
+  <p>
+    <strong>Release notes:</strong> <a href="https://docs.dev.sync.global/release_notes.html" target="_blank" rel="noopener noreferrer">docs.dev.sync.global/release_notes.html</a>
+  </p>
+</div>
+


### PR DESCRIPTION
Wayne: Can we start sending the weekly release announcement to [validator-announce@lists.sync.global](mailto:validator-announce@lists.sync.global)?

* Doing this with Drafts https://groups.io/api#drafts-1 
* `/updatedraft` body needs to be in HTML. The separate Message.html template was placed