### PR TITLE
New: announce to all envs

### DIFF
--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -74,12 +74,12 @@ jobs:
           FILE="tracking/ci/announced-${ENV_LOWER}.txt"
           if [ -f "$FILE" ] && grep -qxF "${GSF_VERSION}" "$FILE"; then
             echo "already_announced=true" >> $GITHUB_OUTPUT
-            echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}."
-            echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}." >> $GITHUB_STEP_SUMMARY
+            echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}." | \
+              tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "already_announced=false" >> $GITHUB_OUTPUT
-            echo "Version ${GSF_VERSION} has not been announced for ${GSF_ENV}."
-            echo "Version ${GSF_VERSION} has not been announced for ${GSF_ENV}." >> $GITHUB_STEP_SUMMARY
+            echo "Version ${GSF_VERSION} has not been announced for ${GSF_ENV}." | \
+              tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
       # Copying binaries for DevNet only
@@ -95,7 +95,7 @@ jobs:
       - name: Run copy-binaries Script
         if: ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
         run: |
-          chmod +x ./main/ci/gsf-copy-binaries.sh && ./main/ci/gsf-copy-binaries.sh
+          ./main/ci/gsf-copy-binaries.sh
 
       # Announcing the release for all environments
       - name: Announce the release to validator-operators
@@ -192,7 +192,7 @@ jobs:
           COUNT=0
           SUCCESS=false
 
-          while [ $COUNT -lt $MAX_RETRIES ]; do
+          while [ $COUNT -le $MAX_RETRIES ]; do
             echo "[INFO] Attempt $((COUNT + 1)) to rebase and push"
           
             git fetch origin "$BRANCH"

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -26,6 +26,9 @@ permissions: {}
 jobs:
   check-and-announce:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Need to write to announce-tracking branch
+      packages: write # Needed for Devnet only. Write to packages when copy images/charts from splice.
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -41,19 +41,28 @@ jobs:
           ref: announce-tracking
           path: tracking
 
-      - name: Get GSF version and docs path
-        id: version
+      - name: Set variables and Get GSF version and docs path
+        id: variables
+        env:
+          GSF_INFO_URL: ${{ inputs.info_url }}
+          GSF_ENV: ${{ inputs.environment }}
         run: |
-          GSF_VERSION=$(curl -sSm5 "${{ inputs.info_url }}/info" | jq -r .sv.version)
-          GSF_DOCS=$(echo "${{ inputs.info_url }}" | sed 's/global.canton.network.//')
+          GSF_VERSION=$(curl -sSm5 "${GSF_INFO_URL}/info" | jq -r .sv.version)
+          GSF_DOCS=$(echo "${GSF_INFO_URL}" | sed 's/global.canton.network.//')
+          echo "GSF_INFO_URL=${GSF_INFO_URL}" >> $GITHUB_ENV
+          echo "GSF_ENV=${GSF_ENV}" >> $GITHUB_ENV
           echo "GSF_VERSION=$GSF_VERSION" >> $GITHUB_ENV
           echo "GSF_DOCS=$GSF_DOCS" >> $GITHUB_ENV
 
       - name: Run SVS majority check
         id: check-majority
+        env:
+          GSF_INFO_URL: ${{ env.GSF_INFO_URL }}
+          GSF_ENV: ${{ env.GSF_ENV }}
+          GITHUB_OUTPUT: $GITHUB_OUTPUT
         run: |
           chmod +x ./main/ci/check-svs-majority.sh
-          result=$(./main/ci/check-svs-majority.sh "${{ inputs.environment }}" "${{ inputs.info_url }}")
+          result=$(./main/ci/check-svs-majority.sh "${GSF_ENV}" "${GSF_INFO_URL}")
           echo "$result"
 
           {
@@ -62,22 +71,22 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-        env:
-          GITHUB_OUTPUT: $GITHUB_OUTPUT
-
       - name: Check if version already announced
         id: check-announced
+        env:
+          GSF_ENV: ${{ env.GSF_ENV }}
+          GSF_VERSION: ${{ env.GSF_VERSION }}
         run: |
-          ENV_LOWER=$(echo "${{ inputs.environment }}" | tr '[:upper:]' '[:lower:]')
+          ENV_LOWER=$(echo "${GSF_ENV}" | tr '[:upper:]' '[:lower:]')
           FILE="tracking/ci/announced-${ENV_LOWER}.txt"
-          if [ -f "$FILE" ] && grep -q "${{ env.GSF_VERSION }}" "$FILE"; then
+          if [ -f "$FILE" ] && grep -q "${GSF_VERSION}" "$FILE"; then
             echo "already_announced=true" >> $GITHUB_OUTPUT
-            echo "Version ${{ env.GSF_VERSION }} has already been announced for ${{ inputs.environment }}."
-            echo "Version ${{ env.GSF_VERSION }} has already been announced for ${{ inputs.environment }}." >> $GITHUB_STEP_SUMMARY
+            echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}."
+            echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}." >> $GITHUB_STEP_SUMMARY
           else
             echo "already_announced=false" >> $GITHUB_OUTPUT
-            echo "Version ${{ env.GSF_VERSION }} has not been announced for ${{ inputs.environment }}."
-            echo "Version ${{ env.GSF_VERSION }} has not been announced for ${{ inputs.environment }}." >> $GITHUB_STEP_SUMMARY
+            echo "Version ${GSF_VERSION} has not been announced for ${GSF_ENV}."
+            echo "Version ${GSF_VERSION} has not been announced for ${GSF_ENV}." >> $GITHUB_STEP_SUMMARY
           fi
 
       # Copying binaries for DevNet only
@@ -98,21 +107,25 @@ jobs:
       # Announcing the release for all environments
       - name: Announce the release to validator-operators
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
+        env:
+          GSF_VERSION: ${{ env.GSF_VERSION }}
+          GSF_ENV: ${{ env.GSF_ENV }}
+          GSF_DOCS: ${{ env.GSF_DOCS }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 #v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "Splice release ${{ env.GSF_VERSION }} is ready for deployment on ${{ inputs.environment }}"
+            text: "Splice release ${GSF_VERSION} is ready for deployment on ${GSF_ENV}"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
                   text: |
-                    :tada: Splice release `${{ env.GSF_VERSION }}` is ready for deployment on ${{ inputs.environment }}, and is available from the GSF
+                    :tada: Splice release `${GSF_VERSION}` is ready for deployment on ${GSF_ENV}, and is available from the GSF
                     :ship: ⅔ of Super Validator nodes have upgraded to this release, including the GSF Super Validator node
                     *SV node status here*: https://sync.global/sv-network
-                    *Release notes here*: ${{ env.GSF_DOCS }}/release_notes.html
+                    *Release notes here*: ${GSF_DOCS}/release_notes.html
 
       - name: Announce to validator-announce@lists.sync.global
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
@@ -120,7 +133,9 @@ jobs:
           VALIDATOR_OPERATORS_GROUP_ID: ${{ inputs.validator_operators_group_id }}
           GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
           GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
-          GSF_ENVIRONMENT: ${{ inputs.environment }}
+          GSF_VERSION: ${{ env.GSF_VERSION }}
+          GSF_ENV: ${{ env.GSF_ENV }}
+          GSF_DOCS: ${{ env.GSF_DOCS }}
         run: |
           trap 'rm -f password.txt cookies.txt message.html' EXIT
 
@@ -163,7 +178,7 @@ jobs:
             -d "csrf=$CSRF_TOKEN" \
             -d "draft_id=$DRAFT_ID" \
             -d "group_id=$VALIDATOR_OPERATORS_GROUP_ID" \
-            -d "subject=Splice release ${{ env.GSF_VERSION }} is ready for deployment on ${{ inputs.environment }}" \
+            -d "subject=Splice release ${GSF_VERSION} is ready for deployment on ${GSF_ENV}" \
             --data-urlencode "body@message.html"
 
           echo "Posting the draft"
@@ -178,7 +193,7 @@ jobs:
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
         run: |
           cd tracking
-          ENV_LOWER=$(echo "${{ inputs.environment }}" | tr '[:upper:]' '[:lower:]')
+          ENV_LOWER=$(echo "${GSF_ENV}" | tr '[:upper:]' '[:lower:]')
           FILE="./ci/announced-${ENV_LOWER}.txt"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
@@ -189,9 +204,9 @@ jobs:
 
           while [ $COUNT -lt $MAX_RETRIES ]; do
             git pull --rebase origin announce-tracking
-            echo "${{ env.GSF_VERSION }}" >> "$FILE" && \
+            echo "${GSF_VERSION}" >> "$FILE" && \
             git add "$FILE" && \
-            git commit -m "Announced ${{ inputs.environment }} ${{ env.GSF_VERSION }}" && \
+            git commit -m "Announced ${GSF_ENV} ${GSF_VERSION}" && \
             git push origin announce-tracking && SUCCESS=true && break
             COUNT=$((COUNT + 1))
             echo "Retrying push... attempt $COUNT"

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: write # Need to write to announce-tracking branch
       packages: write # Needed for Devnet only. Write to packages when copy images/charts from splice.
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -167,7 +168,7 @@ jobs:
           echo "Draft ID: $DRAFT_ID"
 
           VERSION=$GSF_VERSION envsubst < ./main/ci/splice_release_message.html.template > message.html
-          ENVIRONMENT=$GSF_ENVIRONMENT envsubst < message.html > message.html
+          ENVIRONMENT=$GSF_ENV envsubst < message.html > message.html
           DOCS=$GSF_DOCS envsubst < message.html > message.html
 
           echo "Updating draft with message content"

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -36,6 +36,14 @@ jobs:
           ref: announce-tracking
           path: tracking
 
+      - name: Get GSF version and docs path
+        id: version
+        run: |
+          GSF_VERSION=$(curl -sSm5 "${{ inputs.info_url }}/info" | jq -r .sv.version)
+          GSF_DOCS=$(echo "${{ inputs.info_url }}" | sed 's/global.canton.network.//')
+          echo "GSF_VERSION=$GSF_VERSION" >> $GITHUB_ENV
+          echo "GSF_DOCS=$GSF_DOCS" >> $GITHUB_ENV
+
       - name: Run SVS majority check
         id: check-majority
         run: |
@@ -67,17 +75,9 @@ jobs:
             echo "Version ${{ env.GSF_VERSION }} has not been announced for ${{ inputs.environment }}." >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Get GSF version and docs path
-        id: version
-        run: |
-          GSF_VERSION=$(curl -sSm5 "${{ inputs.info_url }}/info" | jq -r .sv.version)
-          GSF_DOCS=$(echo "${{ inputs.info_url }}" | sed 's/global.canton.network.//')
-          echo "GSF_VERSION=$GSF_VERSION" >> $GITHUB_ENV
-          echo "GSF_DOCS=$GSF_DOCS" >> $GITHUB_ENV
-
       # Copying binaries for DevNet only
       - name: Set up tools
-        if : ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
+        if: ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y jq skopeo make
@@ -86,7 +86,7 @@ jobs:
           /tmp/get_helm.sh
 
       - name: Run copy-binaries Script
-        if : ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
+        if: ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
         run: |
           chmod +x ./main/ci/gsf-copy-binaries.sh && ./main/ci/gsf-copy-binaries.sh
 
@@ -112,10 +112,10 @@ jobs:
       - name: Announce to validator-announce@lists.sync.global
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
         env:
-          VALIODATOR_OPERATORS_GROUP_ID: ${{ inputs.validator_operators_group_id }}
+          VALIDATOR_OPERATORS_GROUP_ID: ${{ inputs.validator_operators_group_id }}
           GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
           GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
-          GSF_ENVIRONMENT: ${{ input.environment }}
+          GSF_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           trap 'rm -f password.txt cookies.txt message.html' EXIT
 
@@ -141,7 +141,7 @@ jobs:
               -b "cookies.txt" \
               -d "csrf=$CSRF_TOKEN" \
               -d "draft_type=draft_type_post" \
-              -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID" |
+              -d "group_id=$VALIDATOR_OPERATORS_GROUP_ID" |
             jq -er '.id'
           )
           echo "Draft ID: $DRAFT_ID"
@@ -157,7 +157,7 @@ jobs:
             -b "cookies.txt" \
             -d "csrf=$CSRF_TOKEN" \
             -d "draft_id=$DRAFT_ID" \
-            -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID" \
+            -d "group_id=$VALIDATOR_OPERATORS_GROUP_ID" \
             -d "subject=Splice release ${{ env.GSF_VERSION }} is ready for deployment on ${{ inputs.environment }}" \
             --data-urlencode "body@message.html"
 
@@ -167,7 +167,7 @@ jobs:
             -b "cookies.txt" \
             -d "csrf=$CSRF_TOKEN" \
             -d "draft_id=$DRAFT_ID" \
-            -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID"
+            -d "group_id=$VALIDATOR_OPERATORS_GROUP_ID"
 
       - name: Update announced version file
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -48,21 +48,16 @@ jobs:
           GSF_INFO_URL: ${{ inputs.info_url }}
           GSF_ENV: ${{ inputs.environment }}
         run: |
-          GSF_VERSION=$(curl -sSm5 "${GSF_INFO_URL}/info" | jq -r .sv.version)
-          GSF_DOCS=$(echo "${GSF_INFO_URL}" | sed 's/global.canton.network.//')
-          echo "GSF_INFO_URL=${GSF_INFO_URL}" >> $GITHUB_ENV
-          echo "GSF_ENV=${GSF_ENV}" >> $GITHUB_ENV
+          GSF_VERSION=$(curl -sSm5 "$GSF_INFO_URL/info" | jq -r .sv.version)
+          GSF_DOCS=$(echo "$GSF_INFO_URL" | sed 's/global\.canton\.network\.sync\.global$/sync.global/')
+          echo "GSF_INFO_URL=$GSF_INFO_URL" >> $GITHUB_ENV
+          echo "GSF_ENV=$GSF_ENV" >> $GITHUB_ENV
           echo "GSF_VERSION=$GSF_VERSION" >> $GITHUB_ENV
           echo "GSF_DOCS=$GSF_DOCS" >> $GITHUB_ENV
 
       - name: Run SVS majority check
         id: check-majority
-        env:
-          GSF_INFO_URL: ${{ env.GSF_INFO_URL }}
-          GSF_ENV: ${{ env.GSF_ENV }}
-          GITHUB_OUTPUT: $GITHUB_OUTPUT
         run: |
-          chmod +x ./main/ci/check-svs-majority.sh
           result=$(./main/ci/check-svs-majority.sh "${GSF_ENV}" "${GSF_INFO_URL}")
           echo "$result"
 
@@ -74,13 +69,10 @@ jobs:
 
       - name: Check if version already announced
         id: check-announced
-        env:
-          GSF_ENV: ${{ env.GSF_ENV }}
-          GSF_VERSION: ${{ env.GSF_VERSION }}
         run: |
           ENV_LOWER=$(echo "${GSF_ENV}" | tr '[:upper:]' '[:lower:]')
           FILE="tracking/ci/announced-${ENV_LOWER}.txt"
-          if [ -f "$FILE" ] && grep -q "${GSF_VERSION}" "$FILE"; then
+          if [ -f "$FILE" ] && grep -qxF "${GSF_VERSION}" "$FILE"; then
             echo "already_announced=true" >> $GITHUB_OUTPUT
             echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}."
             echo "Version ${GSF_VERSION} has already been announced for ${GSF_ENV}." >> $GITHUB_STEP_SUMMARY
@@ -108,10 +100,6 @@ jobs:
       # Announcing the release for all environments
       - name: Announce the release to validator-operators
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
-        env:
-          GSF_VERSION: ${{ env.GSF_VERSION }}
-          GSF_ENV: ${{ env.GSF_ENV }}
-          GSF_DOCS: ${{ env.GSF_DOCS }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 #v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -134,9 +122,6 @@ jobs:
           VALIDATOR_OPERATORS_GROUP_ID: ${{ inputs.validator_operators_group_id }}
           GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
           GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
-          GSF_VERSION: ${{ env.GSF_VERSION }}
-          GSF_ENV: ${{ env.GSF_ENV }}
-          GSF_DOCS: ${{ env.GSF_DOCS }}
         run: |
           trap 'rm -f password.txt cookies.txt message.html' EXIT
 
@@ -192,27 +177,58 @@ jobs:
 
       - name: Update announced version file
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
+        shell: bash
         run: |
           cd tracking
           ENV_LOWER=$(echo "${GSF_ENV}" | tr '[:upper:]' '[:lower:]')
           FILE="./ci/announced-${ENV_LOWER}.txt"
+          BRANCH="announce-tracking"
+          MAX_RETRIES=5
+          SLEEP_SEC=2
+
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
-          MAX_RETRIES=5
           COUNT=0
           SUCCESS=false
 
           while [ $COUNT -lt $MAX_RETRIES ]; do
-            git pull --rebase origin announce-tracking
-            echo "${GSF_VERSION}" >> "$FILE" && \
-            git add "$FILE" && \
-            git commit -m "Announced ${GSF_ENV} ${GSF_VERSION}" && \
-            git push origin announce-tracking && SUCCESS=true && break
-            COUNT=$((COUNT + 1))
-            echo "Retrying push... attempt $COUNT"
-            sleep 2
+            echo "[INFO] Attempt $((COUNT + 1)) to rebase and push"
+          
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          
+            if ! git pull --rebase origin "$BRANCH"; then
+              echo "[WARN] Pull with rebase failed"
+              COUNT=$((COUNT + 1))
+              sleep 2
+              continue
+            fi
+          
+            # Only modify file AFTER successful rebase
+            if ! grep -qxF "$GSF_VERSION" "$FILE"; then
+              echo "$GSF_VERSION" >> "$FILE"
+              git add "$FILE"
+              git commit -m "Announced ${GSF_ENV} ${GSF_VERSION}"
+            else
+              echo "[INFO] Version already in file, skipping commit and push"
+              SUCCESS=true
+              break
+            fi
+          
+            if git push origin "$BRANCH"; then
+              echo "[INFO] Push succeeded"
+              SUCCESS=true
+              break
+            else
+              echo "[WARN] Push failed, likely due to concurrent change. Resetting..."
+              git reset --hard HEAD~1      # Roll back the commit
+              git clean -fd                # Discard untracked files, if any
+              COUNT=$((COUNT + 1))
+              sleep 2
+            fi
           done
+
           if [ "$SUCCESS" = false ]; then
             echo "Failed to push after $MAX_RETRIES attempts"
             exit 1

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -21,6 +21,8 @@ on:
       GROUPS_IO_PASS:
         required: true
 
+permissions: {}
+
 jobs:
   check-and-announce:
     runs-on: ubuntu-latest
@@ -93,7 +95,7 @@ jobs:
       # Announcing the release for all environments
       - name: Announce the release to validator-operators
         if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 #v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -1,0 +1,198 @@
+name: Check SVS majority and Announce
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      info_url:
+        required: true
+        type: string
+      validator_operators_group_id:
+        required: false
+        type: string
+        default: "133138"  # Default group ID for validator operators
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+      GROUPS_IO_USER:
+        required: true
+      GROUPS_IO_PASS:
+        required: true
+
+jobs:
+  check-and-announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: main
+
+      - name: Checkout announce-tracking branch
+        uses: actions/checkout@v4
+        with:
+          ref: announce-tracking
+          path: tracking
+
+      - name: Run SVS majority check
+        id: check-majority
+        run: |
+          chmod +x ./main/ci/check-svs-majority.sh
+          result=$(./main/ci/check-svs-majority.sh "${{ inputs.environment }}" "${{ inputs.info_url }}")
+          echo "$result"
+
+          {
+            echo '```'
+            echo "$result"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+        env:
+          GITHUB_OUTPUT: $GITHUB_OUTPUT
+
+      - name: Check if version already announced
+        id: check-announced
+        run: |
+          ENV_LOWER=$(echo "${{ inputs.environment }}" | tr '[:upper:]' '[:lower:]')
+          FILE="tracking/ci/announced-${ENV_LOWER}.txt"
+          if [ -f "$FILE" ] && grep -q "${{ env.GSF_VERSION }}" "$FILE"; then
+            echo "already_announced=true" >> $GITHUB_OUTPUT
+            echo "Version ${{ env.GSF_VERSION }} has already been announced for ${{ inputs.environment }}."
+            echo "Version ${{ env.GSF_VERSION }} has already been announced for ${{ inputs.environment }}." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "already_announced=false" >> $GITHUB_OUTPUT
+            echo "Version ${{ env.GSF_VERSION }} has not been announced for ${{ inputs.environment }}."
+            echo "Version ${{ env.GSF_VERSION }} has not been announced for ${{ inputs.environment }}." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Get GSF version and docs path
+        id: version
+        run: |
+          GSF_VERSION=$(curl -sSm5 "${{ inputs.info_url }}/info" | jq -r .sv.version)
+          GSF_DOCS=$(echo "${{ inputs.info_url }}" | sed 's/global.canton.network.//')
+          echo "GSF_VERSION=$GSF_VERSION" >> $GITHUB_ENV
+          echo "GSF_DOCS=$GSF_DOCS" >> $GITHUB_ENV
+
+      # Copying binaries for DevNet only
+      - name: Set up tools
+        if : ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq skopeo make
+          curl -fsSL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+          chmod 700 /tmp/get_helm.sh
+          /tmp/get_helm.sh
+
+      - name: Run copy-binaries Script
+        if : ${{ inputs.environment == 'DevNet' && steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false' }}
+        run: |
+          chmod +x ./main/ci/gsf-copy-binaries.sh && ./main/ci/gsf-copy-binaries.sh
+
+      # Announcing the release for all environments
+      - name: Announce the release to validator-operators
+        if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Splice release ${{ env.GSF_VERSION }} is ready for deployment on ${{ inputs.environment }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :tada: Splice release `${{ env.GSF_VERSION }}` is ready for deployment on ${{ inputs.environment }}, and is available from the GSF
+                    :ship: ⅔ of Super Validator nodes have upgraded to this release, including the GSF Super Validator node
+                    *SV node status here*: https://sync.global/sv-network
+                    *Release notes here*: ${{ env.GSF_DOCS }}/release_notes.html
+
+      - name: Announce to validator-announce@lists.sync.global
+        if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
+        env:
+          VALIODATOR_OPERATORS_GROUP_ID: ${{ inputs.validator_operators_group_id }}
+          GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
+          GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
+          GSF_ENVIRONMENT: ${{ input.environment }}
+        run: |
+          trap 'rm -f password.txt cookies.txt message.html' EXIT
+
+          curl_options=(-fsS)
+          echo "password=$GROUPS_IO_PASS" > password.txt
+
+          echo "Logging in to groups.io"
+          LOGIN_RESPONSE_COOKIES=$(
+            curl "${curl_options[@]}" -X POST \
+              "https://lists.sync.global/api/v1/login" \
+              -c "cookies.txt" \
+              -d "email=$GROUPS_IO_USER" \
+              -d @password.txt
+          )
+
+          CSRF_TOKEN=$(echo "$LOGIN_RESPONSE_COOKIES" | jq -er '.user.csrf_token')
+          echo "CSRF Token: $CSRF_TOKEN"
+
+          echo "Creating a new draft"
+          DRAFT_ID=$(
+            curl "${curl_options[@]}" -X POST \
+              "https://lists.sync.global/api/v1/newdraft" \
+              -b "cookies.txt" \
+              -d "csrf=$CSRF_TOKEN" \
+              -d "draft_type=draft_type_post" \
+              -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID" |
+            jq -er '.id'
+          )
+          echo "Draft ID: $DRAFT_ID"
+
+          VERSION=$GSF_VERSION envsubst < ./main/ci/splice_release_message.html.template > message.html
+          ENVIRONMENT=$GSF_ENVIRONMENT envsubst < message.html > message.html
+          DOCS=$GSF_DOCS envsubst < message.html > message.html
+
+          echo "Updating draft with message content"
+          curl "${curl_options[@]}" -X POST \
+            "https://lists.sync.global/api/v1/updatedraft" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -b "cookies.txt" \
+            -d "csrf=$CSRF_TOKEN" \
+            -d "draft_id=$DRAFT_ID" \
+            -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID" \
+            -d "subject=Splice release ${{ env.GSF_VERSION }} is ready for deployment on ${{ inputs.environment }}" \
+            --data-urlencode "body@message.html"
+
+          echo "Posting the draft"
+          curl "${curl_options[@]}" -X POST \
+            "https://lists.sync.global/api/v1/postdraft" \
+            -b "cookies.txt" \
+            -d "csrf=$CSRF_TOKEN" \
+            -d "draft_id=$DRAFT_ID" \
+            -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID"
+
+      - name: Update announced version file
+        if: steps.check-majority.outputs.svs_majority == 'true' && steps.check-announced.outputs.already_announced == 'false'
+        run: |
+          cd tracking
+          ENV_LOWER=$(echo "${{ inputs.environment }}" | tr '[:upper:]' '[:lower:]')
+          FILE="./ci/announced-${ENV_LOWER}.txt"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          MAX_RETRIES=5
+          COUNT=0
+          SUCCESS=false
+
+          while [ $COUNT -lt $MAX_RETRIES ]; do
+            git pull --rebase origin announce-tracking
+            echo "${{ env.GSF_VERSION }}" >> "$FILE" && \
+            git add "$FILE" && \
+            git commit -m "Announced ${{ inputs.environment }} ${{ env.GSF_VERSION }}" && \
+            git push origin announce-tracking && SUCCESS=true && break
+            COUNT=$((COUNT + 1))
+            echo "Retrying push... attempt $COUNT"
+            sleep 2
+          done
+          if [ "$SUCCESS" = false ]; then
+            echo "Failed to push after $MAX_RETRIES attempts"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write # Need to write to announce-tracking branch
       packages: write # Needed for Devnet only. Write to packages when copy images/charts from splice. 
+    timeout-minutes: 20
     with:
       environment: DevNet
       info_url: https://docs.dev.global.canton.network.sync.global
@@ -24,6 +25,7 @@ jobs:
     permissions:
       contents: write # Need to write to announce-tracking branch
       packages: read
+    timeout-minutes: 10
     with:
       environment: TestNet
       info_url: https://docs.test.global.canton.network.sync.global
@@ -37,6 +39,7 @@ jobs:
     permissions:
       contents: write # Need to write to announce-tracking branch
       packages: read
+    timeout-minutes: 10
     with:
       environment: MainNet
       info_url: https://docs.global.canton.network.sync.global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,108 +1,39 @@
-name: Binaries CI
+name: Copy Binaries and Announce Release
 
 on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
-  copy-binaries:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_REPO: ${{ github.repository }}
-      GITHUB_ACTOR: ${{ github.actor }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  devnet:
+    uses: ./.github/workflows/.check-majority-and-announce.yml
+    with:
+      environment: DevNet
+      info_url: https://docs.dev.global.canton.network.sync.global
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
+      GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
 
-      - name: Set up tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl jq skopeo make
-          curl -fsSL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-          chmod 700 /tmp/get_helm.sh
-          /tmp/get_helm.sh
+  testnet:
+    uses: ./.github/workflows/.check-majority-and-announce.yml
+    with:
+      environment: TestNet
+      info_url: https://docs.test.global.canton.network.sync.global
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
+      GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
 
-      - name: Run the Script
-        run: |
-          chmod +x ./ci/gsf-copy-binaries.sh && ./ci/gsf-copy-binaries.sh
-
-      - name: Get GSF Devnet Version
-        run: |
-          echo "GSF_DEVNET_VERSION=$(curl -s https://docs.dev.global.canton.network.sync.global/info | jq -r .sv.version)" >> $GITHUB_ENV
-
-      - name: Announce the release to validator-operators
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "Splice release ${{ env.GSF_DEVNET_VERSION }} is ready for deployment on DevNet"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    :tada: Splice release `${{ env.GSF_DEVNET_VERSION }}` is ready for deployment on DevNet, and is available from the GSF
-                    :ship: ⅔ of Super Validator nodes have upgraded to this release, including the GSF Super Validator node
-                    *SV node status here*: https://sync.global/sv-network
-                    *Release notes here*: https://docs.dev.sync.global/release_notes.html
-
-      - name: Announce to validator-announce@lists.sync.global
-        env:
-          VALIODATOR_OPERATORS_GROUP_ID: "133138"
-          GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
-          GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}
-        run: |
-          trap 'rm -f password.txt cookies.txt message.html' EXIT
-
-          curl_options=(-fsS)
-          echo "password=$GROUPS_IO_PASS" > password.txt
-
-          echo "Logging in to groups.io"
-          LOGIN_RESPONSE_COOKIES=$(
-            curl "${curl_options[@]}" -X POST \
-              "https://lists.sync.global/api/v1/login" \
-              -c "cookies.txt" \
-              -d "email=$GROUPS_IO_USER" \
-              -d @password.txt
-          )
-
-          CSRF_TOKEN=$(echo "$LOGIN_RESPONSE_COOKIES" | jq -er '.user.csrf_token')
-          echo "CSRF Token: $CSRF_TOKEN"
-
-          echo "Creating a new draft"
-          DRAFT_ID=$(
-            curl "${curl_options[@]}" -X POST \
-              "https://lists.sync.global/api/v1/newdraft" \
-              -b "cookies.txt" \
-              -d "csrf=$CSRF_TOKEN" \
-              -d "draft_type=draft_type_post" \
-              -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID" |
-            jq -er '.id'
-          )
-          echo "Draft ID: $DRAFT_ID"
-
-          VERSION=$GSF_DEVNET_VERSION envsubst < ./ci/splice_release_message.html.template > message.html
-
-          echo "Updating draft with message content"
-          curl "${curl_options[@]}" -X POST \
-            "https://lists.sync.global/api/v1/updatedraft" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -b "cookies.txt" \
-            -d "csrf=$CSRF_TOKEN" \
-            -d "draft_id=$DRAFT_ID" \
-            -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID" \
-            -d "subject=Splice release ${{ env.GSF_DEVNET_VERSION }} is ready for deployment on DevNet" \
-            --data-urlencode "body@message.html"
-
-          echo "Posting the draft"
-          curl "${curl_options[@]}" -X POST \
-            "https://lists.sync.global/api/v1/postdraft" \
-            -b "cookies.txt" \
-            -d "csrf=$CSRF_TOKEN" \
-            -d "draft_id=$DRAFT_ID" \
-            -d "group_id=$VALIODATOR_OPERATORS_GROUP_ID"
+  mainnet:
+    uses: ./.github/workflows/.check-majority-and-announce.yml
+    with:
+      environment: MainNet
+      info_url: https://docs.global.canton.network.sync.global
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GROUPS_IO_USER: ${{ secrets.GROUPS_IO_USER }}
+      GROUPS_IO_PASS: ${{ secrets.GROUPS_IO_PASS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/.check-majority-and-announce.yml
     permissions:
       contents: write # Need to write to announce-tracking branch
+      packages: read
     with:
       environment: TestNet
       info_url: https://docs.test.global.canton.network.sync.global
@@ -35,6 +36,7 @@ jobs:
     uses: ./.github/workflows/.check-majority-and-announce.yml
     permissions:
       contents: write # Need to write to announce-tracking branch
+      packages: read
     with:
       environment: MainNet
       info_url: https://docs.global.canton.network.sync.global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,14 @@ name: Copy Binaries and Announce Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  packages: write
+permissions: {}
 
 jobs:
   devnet:
     uses: ./.github/workflows/.check-majority-and-announce.yml
+    permissions:
+      contents: write # Need to write to announce-tracking branch
+      packages: write # Needed for Devnet only. Write to packages when copy images/charts from splice. 
     with:
       environment: DevNet
       info_url: https://docs.dev.global.canton.network.sync.global
@@ -20,6 +21,8 @@ jobs:
 
   testnet:
     uses: ./.github/workflows/.check-majority-and-announce.yml
+    permissions:
+      contents: write # Need to write to announce-tracking branch
     with:
       environment: TestNet
       info_url: https://docs.test.global.canton.network.sync.global
@@ -30,6 +33,8 @@ jobs:
 
   mainnet:
     uses: ./.github/workflows/.check-majority-and-announce.yml
+    permissions:
+      contents: write # Need to write to announce-tracking branch
     with:
       environment: MainNet
       info_url: https://docs.global.canton.network.sync.global

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -8,6 +8,7 @@
 # Expects two arguments:
 # 1. GSF_ENV: The environment (e.g., DevNet, TestNet, MainNet).
 # 2. GSF_DOCS: The URL to the GSF documentation.
+# Usage: ./check-svs-majority.sh <GSF_ENV> <GSF_DOCS_URL>
 
 set -euo pipefail
 
@@ -15,27 +16,50 @@ GSF_ENV=$1
 GSF_DOCS=$2
 SVS_MAJORITY="false"
 
+log() {
+    local level="$1"
+    shift
+    echo -e "[$level] $*"
+}
+
+fatal() {
+    log "FATAL" "$1"
+    echo "svs_majority=false" >> "$GITHUB_OUTPUT"
+    exit 1
+}
+
 gsf_version() {
-    GSF_VERSION=$(curl -sSm5 "${GSF_DOCS}/info" | jq -r .sv.version)
+    log "INFO" "Fetching GSF version from: ${GSF_DOCS}/info"
+    GSF_VERSION=$(curl -sSf --max-time 5 "${GSF_DOCS}/info" | jq -er '.sv.version') \
+        || fatal "Failed to fetch or parse GSF version"
 }
 
 check_svs_majority() {
+    log "INFO" "Fetching all SV versions from: ${GSF_DOCS}/versions"
     ALL_VERSIONS=$(curl -sSm5 "${GSF_DOCS}/versions" | \
       awk -F',' 'NR > 1 { gsub(/^ +| +$/, "", $3); print $3 }'
-      )
-    SVS_WITH_GSF_VERSION=$(echo "$ALL_VERSIONS" | grep -c "$GSF_VERSION")
+      ) || fatal "Failed to fetch or parse SV version list"
+    SVS_WITH_GSF_VERSION=$(echo "$ALL_VERSIONS" | grep -cxF "$GSF_VERSION") || true
     ALL_VERSIONS_COUNT=$(echo "$ALL_VERSIONS" | wc -l)
-    echo "GSF ${GSF_ENV} version:               $GSF_VERSION"
-    echo "SVs with GSF version:             $SVS_WITH_GSF_VERSION"
-    echo "SVs needed for 2/3 majority:      $(((ALL_VERSIONS_COUNT +1) * 2 / 3))"
-    echo "Total SVs:                        $ALL_VERSIONS_COUNT"
-    echo "SVs with GSF version percentage:  $((SVS_WITH_GSF_VERSION * 100 / ALL_VERSIONS_COUNT))%"
-    if [ "$SVS_WITH_GSF_VERSION" -lt "$(((ALL_VERSIONS_COUNT +1) * 2 / 3))" ]; then
-        export SVS_MAJORITY="false"
-        echo -e "[ERROR] Not enough SVs with GSF version for majority"
+
+    if [ "$ALL_VERSIONS_COUNT" -eq 0 ]; then
+        fatal "No SV versions found"
+    fi
+
+    REQUIRED_MAJORITY=$(((ALL_VERSIONS_COUNT + 1) * 2 / 3))
+
+    log "INFO" "GSF ${GSF_ENV} version:             $GSF_VERSION"
+    log "INFO" "SVs with GSF version:             $SVS_WITH_GSF_VERSION"
+    log "INFO" "SVs needed for 2/3 majority:      $REQUIRED_MAJORITY"
+    log "INFO" "Total SVs:                        $ALL_VERSIONS_COUNT"
+    log "INFO" "SVs with GSF version percentage:  $((SVS_WITH_GSF_VERSION * 100 / ALL_VERSIONS_COUNT))%"
+
+    if [ "$SVS_WITH_GSF_VERSION" -lt "$REQUIRED_MAJORITY" ]; then
+        SVS_MAJORITY="false"
+        log "ERROR" "Not enough SVs with GSF version for majority"
     else
-        export SVS_MAJORITY="true"
-        echo -e "[INFO] Enough SVs with GSF version for majority"
+        SVS_MAJORITY="true"
+        log "INFO" "Enough SVs with GSF version for majority"
     fi
 }
 

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -11,7 +11,7 @@ gsf_version() {
 }
 
 check_svs_majority() {
-    ALL_VERSIONS=$(curl -sSm5 ${GSF_DOCS}/versions | \
+    ALL_VERSIONS=$(curl -sSm5 "${GSF_DOCS}/versions" | \
       awk -F',' 'NR > 1 { gsub(/^ +| +$/, "", $3); print $3 }'
       )
     SVS_WITH_GSF_VERSION=$(echo "$ALL_VERSIONS" | grep -c "$GSF_VERSION")

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+GSF_ENV=$1
+GSF_DOCS=$2
+GSF_ORG="global-synchronizer-foundation"
+SVS_MAJORITY="false"
+
+gsf_version() {
+    GSF_VERSION=$(curl -sSm5 ${GSF_DOCS}/info | jq -r .sv.version)
+}
+
+check_svs_majority() {
+    ALL_VERSIONS=$(curl -sSm5 ${GSF_DOCS}/versions | \
+      awk -F',' 'NR > 1 { gsub(/^ +| +$/, "", $3); print $3 }'
+      )
+    SVS_WITH_GSF_VERSION=$(echo "$ALL_VERSIONS" | grep -c "$GSF_VERSION")
+    ALL_VERSIONS_COUNT=$(echo "$ALL_VERSIONS" | wc -l)
+    MAJORITY=$(echo "$ALL_VERSIONS" | sort | uniq -c | sort -nr | head -n 1)
+    echo "GSF ${GSF_ENV} version:               $GSF_VERSION"
+    echo "SVs with GSF version:             $SVS_WITH_GSF_VERSION"
+    echo "SVs needed for 2/3 majority:      $(((ALL_VERSIONS_COUNT +1) * 2 / 3))"
+    echo "Total SVs:                        $ALL_VERSIONS_COUNT"
+    echo "SVs with GSF version percentage:  $((SVS_WITH_GSF_VERSION * 100 / ALL_VERSIONS_COUNT))%"
+    if [ "$SVS_WITH_GSF_VERSION" -lt "$(((ALL_VERSIONS_COUNT +1) * 2 / 3))" ]; then
+        export SVS_MAJORITY="false"
+        echo -e "[ERROR] Not enough SVs with GSF version for majority"
+    else
+        export SVS_MAJORITY="true"
+        echo -e "[INFO] Enough SVs with GSF version for majority"
+    fi
+}
+
+gsf_version
+check_svs_majority
+
+echo "svs_majority=$SVS_MAJORITY" >> "$GITHUB_OUTPUT"

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# check-svs-majority.sh
+# This script checks if the current GSF version is present in at least 2/3 of the SVs.
+# It fetches the GSF version from the provided GSF_DOCS URL and compares it against the list of SV versions.
+# If the majority condition is met, it sets the SVS_MAJORITY environment variable to "true", otherwise "false".
+# The result is written to the GITHUB_OUTPUT file as "svs_majority".
+# Expects two arguments:
+# 1. GSF_ENV: The environment (e.g., DevNet, TestNet, MainNet).
+# 2. GSF_DOCS: The URL to the GSF documentation.
+
 set -euo pipefail
 
 GSF_ENV=$1

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 GSF_ENV=$1
 GSF_DOCS=$2
-GSF_ORG="global-synchronizer-foundation"
 SVS_MAJORITY="false"
 
 gsf_version() {

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -16,7 +16,6 @@ check_svs_majority() {
       )
     SVS_WITH_GSF_VERSION=$(echo "$ALL_VERSIONS" | grep -c "$GSF_VERSION")
     ALL_VERSIONS_COUNT=$(echo "$ALL_VERSIONS" | wc -l)
-    MAJORITY=$(echo "$ALL_VERSIONS" | sort | uniq -c | sort -nr | head -n 1)
     echo "GSF ${GSF_ENV} version:               $GSF_VERSION"
     echo "SVs with GSF version:             $SVS_WITH_GSF_VERSION"
     echo "SVs needed for 2/3 majority:      $(((ALL_VERSIONS_COUNT +1) * 2 / 3))"

--- a/ci/check-svs-majority.sh
+++ b/ci/check-svs-majority.sh
@@ -7,7 +7,7 @@ GSF_DOCS=$2
 SVS_MAJORITY="false"
 
 gsf_version() {
-    GSF_VERSION=$(curl -sSm5 ${GSF_DOCS}/info | jq -r .sv.version)
+    GSF_VERSION=$(curl -sSm5 "${GSF_DOCS}/info" | jq -r .sv.version)
 }
 
 check_svs_majority() {


### PR DESCRIPTION
This PR
- Has a reusable workflow and uses it on all environments in separate jobs to avoid mixing variables
- Checks if SVs have the same version as the GSF node and if 2/3 of the nodes are at the same version
- Checks the separate `announce-tracking` git branch which contains files with announced versions per environment
- if GSF version has majority of SVs and this version has not been announced to Validators -- announces it to Slack and groups.io
- Then commits announced version into `announce-tracking` branch into `ci/announced-${ENV}.txt` file
- Currently set to be run manually, but we can use cron to run it each 3 hours or so if agreed on this approach