### PR TITLE
fix: bash flags - catch shell errors

### DIFF
--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 defaults:
   run:
-    shell: bash --noprofile --norc -euo pipefail {0}
+    shell: bash --noprofile --norc -euo pipefail {0}  # GitHub default: bash --noprofile --norc -eo pipefail {0}
 
 jobs:
   check-and-announce:


### PR DESCRIPTION
Added bash flags to catch errors and fail the job.
This should help to avoid situations when the GSF version was not fetched for some reason and an empty version announced to the group
<img width="763" height="123" alt="image" src="https://github.com/user-attachments/assets/c4a1262b-a796-4ffa-aa72-bc245386c352" />
