### PR TITLE
fix: increase job timeout to 30 mins

### DIFF
--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -37,15 +37,15 @@ jobs:
     permissions:
       contents: write # Need to write to announce-tracking branch
       packages: write # Needed for Devnet only. Write to packages when copy images/charts from splice.
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: main
 
       - name: Checkout announce-tracking branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: announce-tracking
           path: tracking


### PR DESCRIPTION
fix: increase job timeout to 30 mins

chore: use git hashes for reusable actions instead of versions
