### PR TITLE
fix: URLs for docs and release-notes in the rss feed

### DIFF
--- a/.github/workflows/.check-majority-and-announce.yml
+++ b/.github/workflows/.check-majority-and-announce.yml
@@ -188,7 +188,7 @@ jobs:
           )
           echo "Draft ID: $DRAFT_ID"
 
-          VERSION=$GSF_VERSION ENVIRONMENT=$GSF_ENV DOCS=$GSF_DOCS envsubst < ./main/ci/splice_release_message.html.template > message.html
+          VERSION=$GSF_VERSION VERSION_ANCHOR=$GSF_VERSION_ANCHOR ENVIRONMENT=$GSF_ENV DOCS=$GSF_DOCS envsubst < ./main/ci/splice_release_message.html.template > message.html
 
           echo "Updating draft with message content"
           curl "${curl_options[@]}" -X POST \

--- a/ci/splice_release_message.html.template
+++ b/ci/splice_release_message.html.template
@@ -12,9 +12,9 @@
     <span>⅔ of Super Validator</span> nodes have upgraded to this release, including the GSF Super Validator node
   </p>
   <p>
-    <strong>SV node status:</strong> <a href="https://sync.global/sv-network" target="_blank" rel="noopener noreferrer">https://sync.global/sv-network</a>
+    <strong>SV node status:</strong> <a href="https://canton.foundation/sv-network-status-2/" target="_blank" rel="noopener noreferrer">SV node status</a>
   </p>
   <p>
-    <strong>Release notes:</strong> <a href="$DOCS/release_notes.html" target="_blank" rel="noopener noreferrer">$DOCS/release_notes.html</a>
+    <strong>Release notes:</strong> <a href="https://docs.canton.network/global-synchronizer/release-notes/splice#$VERSION_ANCHOR" target="_blank" rel="noopener noreferrer">Release notes</a>
   </p>
 </div>


### PR DESCRIPTION
fixes
<img width="2236" height="882" alt="image (19)" src="https://github.com/user-attachments/assets/81955b06-b88e-4bf2-8556-04e7a0a78947" />